### PR TITLE
Portfolio audit: type safety, streaming, server components, UX polish

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
+import { Suspense } from "react";
 import { getTranslations } from "next-intl/server";
-import { z } from "zod";
 import { Card } from "../../components/Card";
 import { Connect } from "../../components/Connect";
 import { Education } from "../../components/Education";
@@ -9,59 +9,23 @@ import { Languages } from "../../components/Languages";
 import { LocaleSwitcher } from "../../components/LocaleSwitcher";
 import { Skills } from "../../components/Skills";
 import { connectItems, skillItems } from "../../data/static-data";
+import { LocaleDataSchema } from "../../schemas/locale";
 
 export const revalidate = 86400;
 
-const GithubRepoSchema = z.object({
-	name: z.string(),
-	description: z.string().nullable().default(""),
-	html_url: z.string().url(),
-	language: z.string().nullable().default(""),
-	stargazers_count: z.number(),
-	fork: z.boolean(),
-});
-
-async function getGithubRepos(): Promise<z.infer<typeof GithubRepoSchema>[]> {
-	try {
-		const res = await fetch(
-			"https://api.github.com/users/aleexnl/repos?sort=stars&per_page=30",
-			{
-				next: { revalidate: 86400 },
-				headers: { Accept: "application/vnd.github.v3+json" },
-			},
-		);
-		if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
-		const data: unknown = await res.json();
-		const parsed = z.array(GithubRepoSchema).safeParse(data);
-		if (!parsed.success) {
-			console.error("GitHub API response validation failed:", parsed.error);
-			return [];
-		}
-		return parsed.data.filter((repo) => !repo.fork).slice(0, 6);
-	} catch (error) {
-		console.error("Error fetching GitHub repos:", error);
-		return [];
-	}
-}
-
 async function getLocaleData(locale: string) {
-	const messages = (await import(`../../../messages/${locale}.json`)).default;
+	const messages: unknown = (
+		await import(`../../../messages/${locale}.json`)
+	).default;
+	const parsed = LocaleDataSchema.safeParse(messages);
+	if (!parsed.success) {
+		console.error("Locale data validation failed:", parsed.error);
+		return { experience: [], education: [], languages: [] };
+	}
 	return {
-		experience: messages.experience.items as Array<{
-			title: string;
-			period: string;
-			company: string;
-			responsibilities: string[];
-		}>,
-		education: messages.education.items as Array<{
-			title: string;
-			institution: string;
-			period: string;
-		}>,
-		languages: messages.languages.items as Array<{
-			name: string;
-			level: string;
-		}>,
+		experience: parsed.data.experience.items,
+		education: parsed.data.education.items,
+		languages: parsed.data.languages.items,
 	};
 }
 
@@ -71,8 +35,7 @@ export default async function Home({
 	params: Promise<{ locale: string }>;
 }) {
 	const { locale } = await params;
-	const [repos, t, tSections, localeData] = await Promise.all([
-		getGithubRepos(),
+	const [t, tSections, localeData] = await Promise.all([
 		getTranslations("home"),
 		getTranslations("sections"),
 		getLocaleData(locale),
@@ -115,14 +78,15 @@ export default async function Home({
 								{t("tagline")}
 							</p>
 						</div>
-						<LocaleSwitcher />
+						<LocaleSwitcher locale={locale} />
 					</div>
 					<div className="mt-8">
-						<GithubProjects
-							repos={repos}
-							title={tSections("featuredProjects")}
-							emptyLabel={tSections("noProjects")}
-						/>
+						<Suspense fallback={<GithubProjectsSkeleton />}>
+							<GithubProjects
+								title={tSections("featuredProjects")}
+								emptyLabel={tSections("noProjects")}
+							/>
+						</Suspense>
 					</div>
 				</header>
 
@@ -156,5 +120,21 @@ export default async function Home({
 				</footer>
 			</main>
 		</>
+	);
+}
+
+function GithubProjectsSkeleton() {
+	return (
+		<div className="rounded-xl border border-gray-100 dark:border-gray-800 p-5">
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				{Array.from({ length: 6 }).map((_, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+					<div
+						key={i}
+						className="h-24 rounded-lg border border-gray-100 dark:border-gray-800 animate-pulse bg-gray-50 dark:bg-gray-900"
+					/>
+				))}
+			</div>
+		</div>
 	);
 }

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 	}
 
-	revalidateTag("github-repos");
+	revalidateTag("github-repos", {});
 
 	return NextResponse.json({ revalidated: true, timestamp: Date.now() });
 }

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,30 @@
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * On-demand ISR endpoint for GitHub repos cache invalidation.
+ *
+ * Register this URL as a GitHub webhook (push/star events) with the secret
+ * set in the REVALIDATE_SECRET environment variable.
+ *
+ * curl -X POST https://your-domain.com/api/revalidate \
+ *   -H "x-revalidate-secret: <secret>"
+ */
+export async function POST(request: NextRequest) {
+	const secret = request.headers.get("x-revalidate-secret");
+
+	if (!process.env.REVALIDATE_SECRET) {
+		return NextResponse.json(
+			{ error: "REVALIDATE_SECRET is not configured" },
+			{ status: 500 },
+		);
+	}
+
+	if (secret !== process.env.REVALIDATE_SECRET) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	revalidateTag("github-repos");
+
+	return NextResponse.json({ revalidated: true, timestamp: Date.now() });
+}

--- a/src/components/GithubProjectItem.tsx
+++ b/src/components/GithubProjectItem.tsx
@@ -1,16 +1,34 @@
-interface GithubRepo {
-	name: string;
-	description: string | null;
-	html_url: string;
-	language: string | null;
-	stargazers_count: number;
-}
+import type { GithubRepo } from "../types/github";
+
+// Source: https://github.com/ozh/github-colors
+const LANGUAGE_COLORS: Record<string, string> = {
+	TypeScript: "#3178c6",
+	JavaScript: "#f1e05a",
+	"C#": "#178600",
+	Python: "#3572A5",
+	Java: "#b07219",
+	Kotlin: "#A97BFF",
+	Swift: "#F05138",
+	Go: "#00ADD8",
+	Rust: "#dea584",
+	Ruby: "#701516",
+	PHP: "#4F5D95",
+	HTML: "#e34c26",
+	CSS: "#563d7c",
+	Shell: "#89e051",
+	Dart: "#00B4AB",
+	Vue: "#41b883",
+};
 
 interface GithubProjectItemProps {
 	repo: GithubRepo;
 }
 
 export function GithubProjectItem({ repo }: GithubProjectItemProps) {
+	const langColor = repo.language
+		? (LANGUAGE_COLORS[repo.language] ?? "#6b7280")
+		: null;
+
 	return (
 		<a
 			href={repo.html_url}
@@ -27,9 +45,12 @@ export function GithubProjectItem({ repo }: GithubProjectItemProps) {
 					{repo.description}
 				</p>
 				<div className="flex items-center justify-between text-xs mt-4">
-					{repo.language && (
+					{langColor && repo.language && (
 						<span className="flex items-center text-gray-400">
-							<span className="w-2 h-2 rounded-full bg-gray-400 mr-1" />
+							<span
+								className="w-2 h-2 rounded-full mr-1"
+								style={{ backgroundColor: langColor }}
+							/>
 							{repo.language}
 						</span>
 					)}

--- a/src/components/GithubProjects.tsx
+++ b/src/components/GithubProjects.tsx
@@ -1,23 +1,16 @@
+import { getGithubRepos } from "../lib/github";
 import { Card } from "./Card";
 import { GithubProjectItem } from "./GithubProjectItem";
 import { ProjectsIcon } from "./icons/ProjectsIcon";
 
-export interface GithubRepo {
-	name: string;
-	description: string | null;
-	html_url: string;
-	language: string | null;
-	stargazers_count: number;
-	fork: boolean;
-}
-
 interface GithubProjectsProps {
-	repos: GithubRepo[];
 	title: string;
 	emptyLabel?: string;
 }
 
-export function GithubProjects({ repos, title, emptyLabel }: GithubProjectsProps) {
+export async function GithubProjects({ title, emptyLabel }: GithubProjectsProps) {
+	const repos = await getGithubRepos();
+
 	return (
 		<Card title={title} icon={<ProjectsIcon />}>
 			{repos.length === 0 ? (

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,21 +1,19 @@
-"use client";
-
-import { Link, usePathname } from "../i18n/navigation";
-import { useLocale } from "next-intl";
+import { Link } from "../i18n/navigation";
 
 const locales = ["en", "ca", "es"] as const;
 
-export function LocaleSwitcher() {
-	const locale = useLocale();
-	const pathname = usePathname();
+interface LocaleSwitcherProps {
+	locale: string;
+}
 
+export function LocaleSwitcher({ locale }: LocaleSwitcherProps) {
 	return (
 		<nav aria-label="Language switcher">
 			<ul className="flex gap-2 text-sm">
 				{locales.map((code) => (
 					<li key={code}>
 						<Link
-							href={pathname}
+							href="/"
 							locale={code}
 							aria-current={locale === code ? "true" : undefined}
 							className={

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import type { GithubRepo } from "../types/github";
+
+const GithubRepoSchema = z.object({
+	name: z.string(),
+	description: z.string().nullable().default(""),
+	html_url: z.string().url(),
+	language: z.string().nullable().default(""),
+	stargazers_count: z.number(),
+	fork: z.boolean(),
+});
+
+export async function getGithubRepos(): Promise<GithubRepo[]> {
+	try {
+		const res = await fetch(
+			"https://api.github.com/users/aleexnl/repos?sort=stars&per_page=30",
+			{
+				next: { tags: ["github-repos"], revalidate: 86400 },
+				headers: { Accept: "application/vnd.github.v3+json" },
+			},
+		);
+		if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+		const data: unknown = await res.json();
+		const parsed = z.array(GithubRepoSchema).safeParse(data);
+		if (!parsed.success) {
+			console.error("GitHub API response validation failed:", parsed.error);
+			return [];
+		}
+		return parsed.data.filter((repo) => !repo.fork).slice(0, 6);
+	} catch (error) {
+		console.error("Error fetching GitHub repos:", error);
+		return [];
+	}
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,5 +9,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-	matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+	matcher: ["/((?!api|_next/static|_next/image|.*\\..*).*)"],
 };

--- a/src/schemas/locale.ts
+++ b/src/schemas/locale.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const ExperienceItemSchema = z.object({
+	title: z.string(),
+	period: z.string(),
+	company: z.string(),
+	responsibilities: z.array(z.string()),
+});
+
+export const EducationItemSchema = z.object({
+	title: z.string(),
+	institution: z.string(),
+	period: z.string(),
+});
+
+export const LanguageItemSchema = z.object({
+	name: z.string(),
+	level: z.string(),
+});
+
+export const LocaleDataSchema = z.object({
+	experience: z.object({ items: z.array(ExperienceItemSchema) }),
+	education: z.object({ items: z.array(EducationItemSchema) }),
+	languages: z.object({ items: z.array(LanguageItemSchema) }),
+});
+
+export type ExperienceItem = z.infer<typeof ExperienceItemSchema>;
+export type EducationItem = z.infer<typeof EducationItemSchema>;
+export type LanguageItem = z.infer<typeof LanguageItemSchema>;

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,8 @@
+export interface GithubRepo {
+	name: string;
+	description: string | null;
+	html_url: string;
+	language: string | null;
+	stargazers_count: number;
+	fork: boolean;
+}

--- a/test/app/api/revalidate/route.test.ts
+++ b/test/app/api/revalidate/route.test.ts
@@ -34,7 +34,7 @@ describe("POST /api/revalidate", () => {
 		const response = await POST(request as never);
 
 		expect(response.status).toBe(200);
-		expect(revalidateTag).toHaveBeenCalledWith("github-repos");
+		expect(revalidateTag).toHaveBeenCalledWith("github-repos", {});
 
 		const body = await response.json();
 		expect(body.revalidated).toBe(true);

--- a/test/app/api/revalidate/route.test.ts
+++ b/test/app/api/revalidate/route.test.ts
@@ -1,0 +1,75 @@
+import { POST } from "../../../../src/app/api/revalidate/route";
+
+vi.mock("next/cache", () => ({
+	revalidateTag: vi.fn(),
+}));
+
+const { revalidateTag } = await import("next/cache");
+
+function makeRequest(secret: string | null): Request {
+	const headers = new Headers();
+	if (secret !== null) {
+		headers.set("x-revalidate-secret", secret);
+	}
+	return new Request("http://localhost/api/revalidate", {
+		method: "POST",
+		headers,
+	});
+}
+
+describe("POST /api/revalidate", () => {
+	const originalSecret = process.env.REVALIDATE_SECRET;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.REVALIDATE_SECRET = "test-secret";
+	});
+
+	afterEach(() => {
+		process.env.REVALIDATE_SECRET = originalSecret;
+	});
+
+	it("returns 200 and revalidates when secret matches", async () => {
+		const request = makeRequest("test-secret");
+		const response = await POST(request as never);
+
+		expect(response.status).toBe(200);
+		expect(revalidateTag).toHaveBeenCalledWith("github-repos");
+
+		const body = await response.json();
+		expect(body.revalidated).toBe(true);
+		expect(body.timestamp).toBeTypeOf("number");
+	});
+
+	it("returns 401 when secret is wrong", async () => {
+		const request = makeRequest("wrong-secret");
+		const response = await POST(request as never);
+
+		expect(response.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+
+		const body = await response.json();
+		expect(body.error).toBe("Unauthorized");
+	});
+
+	it("returns 401 when secret header is missing", async () => {
+		const request = makeRequest(null);
+		const response = await POST(request as never);
+
+		expect(response.status).toBe(401);
+		expect(revalidateTag).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 when REVALIDATE_SECRET env var is not set", async () => {
+		delete process.env.REVALIDATE_SECRET;
+
+		const request = makeRequest("test-secret");
+		const response = await POST(request as never);
+
+		expect(response.status).toBe(500);
+		expect(revalidateTag).not.toHaveBeenCalled();
+
+		const body = await response.json();
+		expect(body.error).toBeDefined();
+	});
+});

--- a/test/app/page.test.tsx
+++ b/test/app/page.test.tsx
@@ -30,8 +30,10 @@ vi.mock("../../src/components/GithubProjects", () => ({
 }));
 
 vi.mock("../../src/components/LocaleSwitcher", () => ({
-	LocaleSwitcher: () => (
-		<div data-testid="locale-switcher">Locale Switcher Mock</div>
+	LocaleSwitcher: ({ locale }: { locale: string }) => (
+		<div data-testid="locale-switcher" data-locale={locale}>
+			Locale Switcher Mock
+		</div>
 	),
 }));
 
@@ -60,6 +62,24 @@ describe("Home Page", () => {
 		expect(screen.getByTestId("languages-component")).toBeInTheDocument();
 	});
 
+	it("renders the locale switcher with current locale", async () => {
+		const HomeComponent = await Home({ params });
+		render(HomeComponent);
+
+		const switcher = screen.getByTestId("locale-switcher");
+		expect(switcher).toBeInTheDocument();
+		expect(switcher).toHaveAttribute("data-locale", "en");
+	});
+
+	it("renders the github projects section inside a suspense boundary", async () => {
+		const HomeComponent = await Home({ params });
+		render(HomeComponent);
+
+		expect(
+			screen.getByTestId("github-projects-component"),
+		).toBeInTheDocument();
+	});
+
 	it("renders footer with current year", async () => {
 		const HomeComponent = await Home({ params });
 		render(HomeComponent);
@@ -72,5 +92,19 @@ describe("Home Page", () => {
 			);
 		});
 		expect(footerText).toBeInTheDocument();
+	});
+
+	it("renders structured data script tag", async () => {
+		const HomeComponent = await Home({ params });
+		const { container } = render(HomeComponent);
+
+		const scriptTag = container.querySelector(
+			'script[type="application/ld+json"]',
+		);
+		expect(scriptTag).toBeInTheDocument();
+
+		const jsonLd = JSON.parse(scriptTag?.innerHTML ?? "{}");
+		expect(jsonLd["@type"]).toBe("Person");
+		expect(jsonLd.name).toBe("Alejandro Nieto Luque");
 	});
 });

--- a/test/components/GithubProjectItem.test.tsx
+++ b/test/components/GithubProjectItem.test.tsx
@@ -8,6 +8,7 @@ describe("GithubProjectItem", () => {
 		html_url: "https://github.com/test/repo",
 		language: "TypeScript",
 		stargazers_count: 42,
+		fork: false,
 	};
 
 	it("renders repository information correctly", () => {
@@ -24,11 +25,62 @@ describe("GithubProjectItem", () => {
 		expect(link).toHaveAttribute("rel", "noopener noreferrer");
 	});
 
+	it("renders accessible aria-label with repo name", () => {
+		render(<GithubProjectItem repo={mockRepo} />);
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute(
+			"aria-label",
+			"test-repo (opens in new tab)",
+		);
+	});
+
 	it("handles repository without language", () => {
-		const repoWithoutLang = { ...mockRepo, language: "" };
+		const repoWithoutLang = { ...mockRepo, language: null };
 		render(<GithubProjectItem repo={repoWithoutLang} />);
 
 		expect(screen.getByText("test-repo")).toBeInTheDocument();
 		expect(screen.queryByText("TypeScript")).not.toBeInTheDocument();
+	});
+
+	it("renders language dot with known language color for TypeScript", () => {
+		const { container } = render(<GithubProjectItem repo={mockRepo} />);
+
+		const dot = container.querySelector("span[style]");
+		expect(dot).toBeInTheDocument();
+		expect(dot).toHaveStyle({ backgroundColor: "#3178c6" });
+	});
+
+	it("renders language dot with fallback color for unknown language", () => {
+		const repoUnknownLang = { ...mockRepo, language: "UnknownLang" };
+		const { container } = render(<GithubProjectItem repo={repoUnknownLang} />);
+
+		const dot = container.querySelector("span[style]");
+		expect(dot).toBeInTheDocument();
+		expect(dot).toHaveStyle({ backgroundColor: "#6b7280" });
+	});
+
+	it("renders correct color for JavaScript", () => {
+		const jsRepo = { ...mockRepo, language: "JavaScript" };
+		const { container } = render(<GithubProjectItem repo={jsRepo} />);
+
+		const dot = container.querySelector("span[style]");
+		expect(dot).toHaveStyle({ backgroundColor: "#f1e05a" });
+	});
+
+	it("renders correct color for C#", () => {
+		const csRepo = { ...mockRepo, language: "C#" };
+		const { container } = render(<GithubProjectItem repo={csRepo} />);
+
+		const dot = container.querySelector("span[style]");
+		expect(dot).toHaveStyle({ backgroundColor: "#178600" });
+	});
+
+	it("does not render language dot when language is null", () => {
+		const repoNoLang = { ...mockRepo, language: null };
+		const { container } = render(<GithubProjectItem repo={repoNoLang} />);
+
+		const dot = container.querySelector("span[style]");
+		expect(dot).not.toBeInTheDocument();
 	});
 });

--- a/test/components/GithubProjects.test.tsx
+++ b/test/components/GithubProjects.test.tsx
@@ -1,8 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { GithubProjects } from "../../src/components/GithubProjects";
-
-// Mock fetch globally
-vi.stubGlobal("fetch", vi.fn());
 
 // Mock the async server component
 vi.mock("../../src/components/GithubProjects", () => ({
@@ -31,23 +28,26 @@ describe("GithubProjects", () => {
 	];
 
 	beforeEach(() => {
-		// Reset all mocks before each test
 		vi.resetAllMocks();
 
-		// Setup mock implementation for the server component
-		vi.mocked(GithubProjects).mockImplementation(() => (
-			<div data-testid="github-projects">
-				<div>{mockRepos[0].name}</div>
-				<div>{mockRepos[0].description}</div>
-				<div>{mockRepos[0].language}</div>
-				<div>{mockRepos[0].stargazers_count}</div>
-				<div>{mockRepos[1].name}</div>
-			</div>
-		));
+		vi.mocked(GithubProjects).mockImplementation(
+			// Cast needed: mock is synchronous but component type is async
+			(() => (
+				<div data-testid="github-projects">
+					<div>{mockRepos[0].name}</div>
+					<div>{mockRepos[0].description}</div>
+					<div>{mockRepos[0].language}</div>
+					<div>{mockRepos[0].stargazers_count}</div>
+					<div>{mockRepos[1].name}</div>
+				</div>
+			)) as unknown as typeof GithubProjects,
+		);
 	});
 
 	it("renders the GitHub projects component", async () => {
-		render(<GithubProjects />);
+		await act(async () => {
+			render(<GithubProjects title="Featured Projects" />);
+		});
 
 		expect(screen.getByTestId("github-projects")).toBeInTheDocument();
 		expect(screen.getByText("repo-1")).toBeInTheDocument();
@@ -57,12 +57,15 @@ describe("GithubProjects", () => {
 	});
 
 	it("handles empty repos gracefully", async () => {
-		// Mock the server component to return a fallback message
-		vi.mocked(GithubProjects).mockImplementation(() => (
-			<div data-testid="github-projects-empty">No projects available.</div>
-		));
+		vi.mocked(GithubProjects).mockImplementation(
+			(() => (
+				<div data-testid="github-projects-empty">No projects available.</div>
+			)) as unknown as typeof GithubProjects,
+		);
 
-		render(<GithubProjects />);
+		await act(async () => {
+			render(<GithubProjects title="Featured Projects" />);
+		});
 
 		expect(screen.getByTestId("github-projects-empty")).toBeInTheDocument();
 		expect(screen.getByText("No projects available.")).toBeInTheDocument();

--- a/test/components/LocaleSwitcher.test.tsx
+++ b/test/components/LocaleSwitcher.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { LocaleSwitcher } from "../../src/components/LocaleSwitcher";
 
 vi.mock("../../src/i18n/navigation", () => ({
-	usePathname: () => "/en",
 	Link: ({
 		href,
 		locale,
@@ -22,7 +21,7 @@ vi.mock("../../src/i18n/navigation", () => ({
 
 describe("LocaleSwitcher", () => {
 	it("renders all locale links", () => {
-		render(<LocaleSwitcher />);
+		render(<LocaleSwitcher locale="en" />);
 
 		expect(screen.getByRole("link", { name: "EN" })).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "CA" })).toBeInTheDocument();
@@ -30,7 +29,7 @@ describe("LocaleSwitcher", () => {
 	});
 
 	it("marks active locale with aria-current", () => {
-		render(<LocaleSwitcher />);
+		render(<LocaleSwitcher locale="en" />);
 
 		const enLink = screen.getByRole("link", { name: "EN" });
 		expect(enLink).toHaveAttribute("aria-current", "true");
@@ -39,11 +38,45 @@ describe("LocaleSwitcher", () => {
 		expect(caLink).not.toHaveAttribute("aria-current");
 	});
 
+	it("marks correct locale as active when locale is ca", () => {
+		render(<LocaleSwitcher locale="ca" />);
+
+		const caLink = screen.getByRole("link", { name: "CA" });
+		expect(caLink).toHaveAttribute("aria-current", "true");
+
+		const enLink = screen.getByRole("link", { name: "EN" });
+		expect(enLink).not.toHaveAttribute("aria-current");
+	});
+
+	it("marks correct locale as active when locale is es", () => {
+		render(<LocaleSwitcher locale="es" />);
+
+		const esLink = screen.getByRole("link", { name: "ES" });
+		expect(esLink).toHaveAttribute("aria-current", "true");
+	});
+
 	it("has accessible nav label", () => {
-		render(<LocaleSwitcher />);
+		render(<LocaleSwitcher locale="en" />);
 
 		expect(
 			screen.getByRole("navigation", { name: "Language switcher" }),
 		).toBeInTheDocument();
+	});
+
+	it("renders correct href for each locale", () => {
+		render(<LocaleSwitcher locale="en" />);
+
+		expect(screen.getByRole("link", { name: "EN" })).toHaveAttribute(
+			"href",
+			"/en",
+		);
+		expect(screen.getByRole("link", { name: "CA" })).toHaveAttribute(
+			"href",
+			"/ca",
+		);
+		expect(screen.getByRole("link", { name: "ES" })).toHaveAttribute(
+			"href",
+			"/es",
+		);
 	});
 });

--- a/test/components/icons/SkillsIcon.test.tsx
+++ b/test/components/icons/SkillsIcon.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react";
+import { SkillsIcon } from "../../../src/components/icons/SkillsIcon";
+
+describe("SkillsIcon", () => {
+	it("renders with default className", () => {
+		const { container } = render(<SkillsIcon />);
+		const svg = container.querySelector("svg");
+		expect(svg).toBeInTheDocument();
+		expect(svg).toHaveClass("w-5", "h-5");
+	});
+
+	it("renders with custom className", () => {
+		const { container } = render(<SkillsIcon className="w-8 h-8" />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveClass("w-8", "h-8");
+		expect(svg).not.toHaveClass("w-5", "h-5");
+	});
+
+	it("renders with correct svg attributes", () => {
+		const { container } = render(<SkillsIcon />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveAttribute("fill", "none");
+		expect(svg).toHaveAttribute("stroke", "currentColor");
+		expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+	});
+
+	it("renders with correct stroke path attributes", () => {
+		const { container } = render(<SkillsIcon />);
+		const path = container.querySelector("path");
+		expect(path?.getAttribute("stroke-linecap")).toBe("round");
+		expect(path?.getAttribute("stroke-linejoin")).toBe("round");
+		expect(path?.getAttribute("stroke-width")).toBe("2");
+	});
+
+	it("renders an accessible title", () => {
+		const { container } = render(<SkillsIcon />);
+		const title = container.querySelector("title");
+		expect(title).toBeInTheDocument();
+		expect(title?.textContent).toBe("Skills");
+	});
+});

--- a/test/lib/github.test.ts
+++ b/test/lib/github.test.ts
@@ -1,0 +1,143 @@
+import { getGithubRepos } from "../../src/lib/github";
+
+const mockRepos = [
+	{
+		name: "repo-1",
+		description: "First repository",
+		html_url: "https://github.com/aleexnl/repo-1",
+		language: "TypeScript",
+		stargazers_count: 10,
+		fork: false,
+	},
+	{
+		name: "repo-2",
+		description: "Second repository",
+		html_url: "https://github.com/aleexnl/repo-2",
+		language: "JavaScript",
+		stargazers_count: 5,
+		fork: false,
+	},
+	{
+		name: "forked-repo",
+		description: "A forked repository",
+		html_url: "https://github.com/aleexnl/forked-repo",
+		language: "Python",
+		stargazers_count: 100,
+		fork: true,
+	},
+];
+
+describe("getGithubRepos", () => {
+	beforeEach(() => {
+		vi.stubGlobal("fetch", vi.fn());
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("returns parsed and filtered repos on success", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify(mockRepos), { status: 200 }),
+		);
+
+		const repos = await getGithubRepos();
+
+		expect(repos).toHaveLength(2);
+		expect(repos[0].name).toBe("repo-1");
+		expect(repos[1].name).toBe("repo-2");
+	});
+
+	it("filters out forked repositories", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify(mockRepos), { status: 200 }),
+		);
+
+		const repos = await getGithubRepos();
+
+		const forked = repos.find((r) => r.fork === true);
+		expect(forked).toBeUndefined();
+	});
+
+	it("returns at most 6 repositories", async () => {
+		const manyRepos = Array.from({ length: 10 }, (_, i) => ({
+			name: `repo-${i}`,
+			description: `Repo ${i}`,
+			html_url: `https://github.com/aleexnl/repo-${i}`,
+			language: "TypeScript",
+			stargazers_count: i,
+			fork: false,
+		}));
+
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify(manyRepos), { status: 200 }),
+		);
+
+		const repos = await getGithubRepos();
+		expect(repos.length).toBeLessThanOrEqual(6);
+	});
+
+	it("returns empty array when API responds with non-ok status", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(null, { status: 403 }),
+		);
+
+		const repos = await getGithubRepos();
+		expect(repos).toEqual([]);
+	});
+
+	it("returns empty array when fetch throws a network error", async () => {
+		vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+		const repos = await getGithubRepos();
+		expect(repos).toEqual([]);
+	});
+
+	it("returns empty array when API response fails Zod validation", async () => {
+		const invalidData = [{ invalid: "shape" }];
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify(invalidData), { status: 200 }),
+		);
+
+		const repos = await getGithubRepos();
+		expect(repos).toEqual([]);
+	});
+
+	it("handles repos with null description and language", async () => {
+		const reposWithNulls = [
+			{
+				name: "null-fields-repo",
+				description: null,
+				html_url: "https://github.com/aleexnl/null-fields-repo",
+				language: null,
+				stargazers_count: 3,
+				fork: false,
+			},
+		];
+
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify(reposWithNulls), { status: 200 }),
+		);
+
+		const repos = await getGithubRepos();
+		expect(repos).toHaveLength(1);
+		// Zod nullable() preserves null values; default("") only applies to undefined
+		expect(repos[0].description).toBeNull();
+		expect(repos[0].language).toBeNull();
+	});
+
+	it("calls the GitHub API with correct headers", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify([]), { status: 200 }),
+		);
+
+		await getGithubRepos();
+
+		expect(fetch).toHaveBeenCalledWith(
+			"https://api.github.com/users/aleexnl/repos?sort=stars&per_page=30",
+			expect.objectContaining({
+				headers: { Accept: "application/vnd.github.v3+json" },
+			}),
+		);
+	});
+});

--- a/test/schemas/locale.test.ts
+++ b/test/schemas/locale.test.ts
@@ -1,0 +1,169 @@
+import {
+	LocaleDataSchema,
+	ExperienceItemSchema,
+	EducationItemSchema,
+	LanguageItemSchema,
+} from "../../src/schemas/locale";
+
+describe("ExperienceItemSchema", () => {
+	it("parses a valid experience item", () => {
+		const result = ExperienceItemSchema.safeParse({
+			title: "Software Engineer",
+			period: "2022 - Present",
+			company: "Acme Corp",
+			responsibilities: ["Built features", "Reviewed PRs"],
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.title).toBe("Software Engineer");
+			expect(result.data.responsibilities).toHaveLength(2);
+		}
+	});
+
+	it("fails when title is missing", () => {
+		const result = ExperienceItemSchema.safeParse({
+			period: "2022 - Present",
+			company: "Acme Corp",
+			responsibilities: [],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("fails when responsibilities is not an array", () => {
+		const result = ExperienceItemSchema.safeParse({
+			title: "Engineer",
+			period: "2022 - Present",
+			company: "Acme",
+			responsibilities: "Built features",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("EducationItemSchema", () => {
+	it("parses a valid education item", () => {
+		const result = EducationItemSchema.safeParse({
+			title: "BSc Computer Science",
+			institution: "University of Barcelona",
+			period: "2018 - 2022",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.institution).toBe("University of Barcelona");
+		}
+	});
+
+	it("fails when institution is missing", () => {
+		const result = EducationItemSchema.safeParse({
+			title: "BSc Computer Science",
+			period: "2018 - 2022",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("LanguageItemSchema", () => {
+	it("parses a valid language item", () => {
+		const result = LanguageItemSchema.safeParse({
+			name: "Spanish",
+			level: "Native",
+		});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.name).toBe("Spanish");
+			expect(result.data.level).toBe("Native");
+		}
+	});
+
+	it("fails when level is missing", () => {
+		const result = LanguageItemSchema.safeParse({ name: "Spanish" });
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("LocaleDataSchema", () => {
+	const validData = {
+		experience: {
+			items: [
+				{
+					title: "Engineer",
+					period: "2022 - Present",
+					company: "Acme",
+					responsibilities: ["Task A"],
+				},
+			],
+		},
+		education: {
+			items: [
+				{
+					title: "BSc CS",
+					institution: "University",
+					period: "2018 - 2022",
+				},
+			],
+		},
+		languages: {
+			items: [{ name: "Spanish", level: "Native" }],
+		},
+	};
+
+	it("parses valid locale data", () => {
+		const result = LocaleDataSchema.safeParse(validData);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.experience.items).toHaveLength(1);
+			expect(result.data.education.items).toHaveLength(1);
+			expect(result.data.languages.items).toHaveLength(1);
+		}
+	});
+
+	it("parses locale data with empty item arrays", () => {
+		const emptyData = {
+			experience: { items: [] },
+			education: { items: [] },
+			languages: { items: [] },
+		};
+
+		const result = LocaleDataSchema.safeParse(emptyData);
+		expect(result.success).toBe(true);
+	});
+
+	it("fails when experience section is missing", () => {
+		const { experience: _experience, ...withoutExperience } = validData;
+		const result = LocaleDataSchema.safeParse(withoutExperience);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("fails when education section is missing", () => {
+		const { education: _education, ...withoutEducation } = validData;
+		const result = LocaleDataSchema.safeParse(withoutEducation);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("fails on null input", () => {
+		const result = LocaleDataSchema.safeParse(null);
+		expect(result.success).toBe(false);
+	});
+
+	it("fails when experience item has invalid structure", () => {
+		const invalidData = {
+			...validData,
+			experience: {
+				items: [{ title: "Engineer" }], // missing required fields
+			},
+		};
+
+		const result = LocaleDataSchema.safeParse(invalidData);
+		expect(result.success).toBe(false);
+	});
+});


### PR DESCRIPTION
- Type safety: Move GithubRepo to src/types/github.ts (single source of truth,
  removes duplicate local declaration in GithubProjectItem)
- Type safety: Add Zod schemas in src/schemas/locale.ts and validate locale
  JSON in getLocaleData — fixes silent any cast on dynamic template import
- Type safety: Extract getGithubRepos to src/lib/github.ts with revalidateTag
  for on-demand ISR support
- Architecture: Make GithubProjects an async Server Component that owns its
  own data fetch; wrap in <Suspense> so the page streams without blocking on
  the GitHub API
- Architecture: Convert LocaleSwitcher from "use client" to a pure Server
  Component by accepting locale as a prop — eliminates unnecessary client JS
- UX: Add LANGUAGE_COLORS map to GithubProjectItem so language dots render
  with the correct GitHub language color instead of a generic gray
- Feature: Add /api/revalidate route for on-demand ISR via GitHub webhook,
  secured with REVALIDATE_SECRET env var

https://claude.ai/code/session_01TwBS8cBPmaEKRoaz2Z6A5w