### PR TITLE
Fix i18n routing to use root URL for default English locale

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -46,10 +46,13 @@ export async function generateMetadata({
 		},
 		manifest: "/site.webmanifest",
 		alternates: {
-			canonical: `https://aleexnl.com/${locale}`,
+			canonical:
+				locale === "en"
+					? "https://aleexnl.com/"
+					: `https://aleexnl.com/${locale}`,
 			languages: {
-				"x-default": "https://aleexnl.com/en",
-				en: "https://aleexnl.com/en",
+				"x-default": "https://aleexnl.com/",
+				en: "https://aleexnl.com/",
 				ca: "https://aleexnl.com/ca",
 				es: "https://aleexnl.com/es",
 			},
@@ -60,7 +63,10 @@ export async function generateMetadata({
 				({ en: "en_US", ca: "ca_ES", es: "es_ES" } as Record<string, string>)[
 					locale
 				] ?? "en_US",
-			url: `https://aleexnl.com/${locale}`,
+			url:
+				locale === "en"
+					? "https://aleexnl.com/"
+					: `https://aleexnl.com/${locale}`,
 			title: t("title"),
 			description: t("description"),
 		},

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -47,7 +47,10 @@ export default async function Home({
 		"@type": "Person",
 		name: "Alejandro Nieto Luque",
 		jobTitle: t("tagline"),
-		url: `https://aleexnl.com/${locale}`,
+		url:
+			locale === "en"
+				? "https://aleexnl.com/"
+				: `https://aleexnl.com/${locale}`,
 		sameAs: [
 			"https://www.linkedin.com/in/alejandro-nieto-luque/",
 			"https://github.com/aleexnl",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
 	return [
 		{
-			url: "https://aleexnl.com/en",
+			url: "https://aleexnl.com/",
 			lastModified: new Date(),
 			changeFrequency: "monthly",
 			priority: 1,

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -3,4 +3,5 @@ import { defineRouting } from "next-intl/routing";
 export const routing = defineRouting({
 	locales: ["en", "ca", "es"],
 	defaultLocale: "en",
+	localePrefix: "as-needed",
 });

--- a/test/app/layout.test.tsx
+++ b/test/app/layout.test.tsx
@@ -1,0 +1,94 @@
+import { generateMetadata } from "../../src/app/[locale]/layout";
+
+vi.mock("next/font/google", () => ({
+	Roboto: () => ({ variable: "--font-roboto" }),
+}));
+
+vi.mock("next-intl/server", () => ({
+	getMessages: vi.fn().mockResolvedValue({}),
+	getTranslations: vi.fn().mockImplementation(({ namespace }) => {
+		const translations: Record<string, Record<string, string>> = {
+			meta: {
+				title: "Alejandro - Software Developer",
+				description: "Test description",
+			},
+			nav: { skipToContent: "Skip to content" },
+		};
+		return Promise.resolve(
+			(key: string) => translations[namespace]?.[key] ?? "",
+		);
+	}),
+}));
+
+describe("generateMetadata", () => {
+	describe("English locale (default)", () => {
+		const params = Promise.resolve({ locale: "en" });
+
+		it("sets canonical to the root URL", async () => {
+			const metadata = await generateMetadata({ params });
+
+			expect(metadata.alternates?.canonical).toBe("https://aleexnl.com/");
+		});
+
+		it("sets x-default hreflang to the root URL", async () => {
+			const metadata = await generateMetadata({ params });
+			const languages = metadata.alternates?.languages as Record<
+				string,
+				string
+			>;
+
+			expect(languages["x-default"]).toBe("https://aleexnl.com/");
+		});
+
+		it("sets en hreflang to the root URL", async () => {
+			const metadata = await generateMetadata({ params });
+			const languages = metadata.alternates?.languages as Record<
+				string,
+				string
+			>;
+
+			expect(languages.en).toBe("https://aleexnl.com/");
+		});
+
+		it("sets OpenGraph url to the root URL", async () => {
+			const metadata = await generateMetadata({ params });
+
+			expect(metadata.openGraph?.url).toBe("https://aleexnl.com/");
+		});
+	});
+
+	describe("Non-default locales", () => {
+		it("sets canonical to /ca for Catalan", async () => {
+			const params = Promise.resolve({ locale: "ca" });
+			const metadata = await generateMetadata({ params });
+
+			expect(metadata.alternates?.canonical).toBe("https://aleexnl.com/ca");
+		});
+
+		it("sets canonical to /es for Spanish", async () => {
+			const params = Promise.resolve({ locale: "es" });
+			const metadata = await generateMetadata({ params });
+
+			expect(metadata.alternates?.canonical).toBe("https://aleexnl.com/es");
+		});
+
+		it("sets OpenGraph url to /ca for Catalan", async () => {
+			const params = Promise.resolve({ locale: "ca" });
+			const metadata = await generateMetadata({ params });
+
+			expect(metadata.openGraph?.url).toBe("https://aleexnl.com/ca");
+		});
+
+		it("sets ca and es hreflang to locale-prefixed URLs", async () => {
+			const params = Promise.resolve({ locale: "es" });
+			const metadata = await generateMetadata({ params });
+			const languages = metadata.alternates?.languages as Record<
+				string,
+				string
+			>;
+
+			expect(languages.ca).toBe("https://aleexnl.com/ca");
+			expect(languages.es).toBe("https://aleexnl.com/es");
+		});
+	});
+});

--- a/test/app/sitemap.test.ts
+++ b/test/app/sitemap.test.ts
@@ -1,0 +1,34 @@
+import sitemap from "../../src/app/sitemap";
+
+describe("sitemap", () => {
+	it("includes the root URL for English instead of /en", () => {
+		const entries = sitemap();
+		const urls = entries.map((e) => e.url);
+
+		expect(urls).toContain("https://aleexnl.com/");
+		expect(urls).not.toContain("https://aleexnl.com/en");
+	});
+
+	it("includes /ca and /es locale URLs", () => {
+		const entries = sitemap();
+		const urls = entries.map((e) => e.url);
+
+		expect(urls).toContain("https://aleexnl.com/ca");
+		expect(urls).toContain("https://aleexnl.com/es");
+	});
+
+	it("returns 3 entries", () => {
+		const entries = sitemap();
+
+		expect(entries).toHaveLength(3);
+	});
+
+	it("sets priority 1 and changeFrequency monthly on all entries", () => {
+		const entries = sitemap();
+
+		for (const entry of entries) {
+			expect(entry.priority).toBe(1);
+			expect(entry.changeFrequency).toBe("monthly");
+		}
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	plugins: [react()],
+	css: {
+		postcss: { plugins: [] },
+	},
 	test: {
 		environment: "jsdom",
 		globals: true,


### PR DESCRIPTION
## Summary
This PR fixes the internationalization routing configuration to properly handle the default English locale by serving it at the root URL (`/`) instead of `/en`, while maintaining locale-prefixed URLs for non-default locales (`/ca`, `/es`).

## Key Changes
- **Updated `next-intl` routing configuration** (`src/app/i18n/routing.ts`):
  - Added `localePrefix: "as-needed"` to the routing config, which automatically omits the locale prefix for the default locale

- **Fixed canonical and OpenGraph URLs** (`src/app/[locale]/layout.tsx`):
  - Updated `canonical` URL to use root URL for English (`https://aleexnl.com/`) instead of `/en`
  - Updated `x-default` and `en` hreflang entries to point to root URL
  - Updated OpenGraph `url` to use root URL for English locale

- **Fixed structured data URL** (`src/app/[locale]/page.tsx`):
  - Updated Person schema `url` to use root URL for English locale

- **Fixed sitemap** (`src/app/sitemap.ts`):
  - Changed English entry from `https://aleexnl.com/en` to `https://aleexnl.com/`

- **Added comprehensive test coverage**:
  - New test file `test/app/layout.test.tsx` with tests for metadata generation across locales
  - New test file `test/app/sitemap.test.ts` with tests for sitemap entries
  - Updated `vitest.config.ts` to properly handle PostCSS configuration in tests

## Implementation Details
The changes ensure that:
- The English locale (default) is served at the root path without a locale prefix
- Non-default locales (Catalan, Spanish) maintain their locale-prefixed paths
- All SEO metadata (canonical tags, hreflang, OpenGraph) correctly reflect the URL structure
- The sitemap accurately represents the site's URL structure
- Tests verify the correct behavior across all supported locales

https://claude.ai/code/session_01NiLC1jtuBsy2Wiv7Ms7Jsw